### PR TITLE
don't crash when several destroys are triggered for the same jewel

### DIFF
--- a/main.py
+++ b/main.py
@@ -378,7 +378,8 @@ class Jewel(Widget):
 
     def on_complete(self, *args):
         self.animating = False
-        self.board.check(self)
+        if self.board:
+            self.board.check(self)
 
     def stop(self):
         if self.anim:

--- a/main.py
+++ b/main.py
@@ -398,8 +398,9 @@ class Jewel(Widget):
         self.explode(nosound=True)
 
     def destroy(self, *args):
-        self.board.remove_widget(self)
-        self.board = None
+        if self.board:
+            self.board.remove_widget(self)
+            self.board = None
 
     def highlight(self):
         if self.anim_highlight:


### PR DESCRIPTION
I had the game crash on me a couple of times with:

```
AttributeError: 'NoneType' object has no attribute 'remove_widget'
```

I think this fixes the issue (at least it hasn't crashed on me since).
