### PR TITLE
Fixed a crash that sometimes occurs

### DIFF
--- a/main.py
+++ b/main.py
@@ -398,8 +398,9 @@ class Jewel(Widget):
         self.explode(nosound=True)
 
     def destroy(self, *args):
-        self.board.remove_widget(self)
-        self.board = None
+        if self.board is not None:
+            self.board.remove_widget(self)
+            self.board = None
 
     def highlight(self):
         if self.anim_highlight:


### PR DESCRIPTION
Sometimes when you happen to snag a big combo (like area bomb into multiple area/line bombs) the game crashes, citing line 401 as the source, saying something about removing type "NoneType" widget from the board.

Just a hunch, I believe this is because when a widget is removed from the board, then set to None, destroy() is again called from explode() with said NoneType widget before the explode()'s widget reference is "updated" to the next widget, during big combos.

I changed the area & line bomb to generate on every "normal" 3-jewel clear so I could get massive combos easily to test. From some limited testing this change appears to prevent the crash.
